### PR TITLE
update jupyterlab-server-proxy reference

### DIFF
--- a/postBuild
+++ b/postBuild
@@ -2,7 +2,7 @@
 
 # Enable the proxy extension in notebook and lab
 jupyter serverextension enable --py jupyter_server_proxy
-jupyter labextension install jupyterlab-server-proxy
+jupyter labextension install @jupyterlab/server-proxy
 jupyter lab build
 
 code-server --install-extension ms-python.python


### PR DESCRIPTION
The npm package was moved to the jupyterlab organization, this PR updates installation command.
This also fixes the dependency errors raised in docker builds:
```
...
JupyterLab              Extension      Package
>=1.2.1 <1.3.0          >=0.19.1 <0.20.0@jupyterlab/application
>=1.2.1 <1.3.0          >=0.19.1 <0.20.0@jupyterlab/launcher
...
```
See [here](https://mybinder.org/v2/gh/fhoehle/vscode-binder.git/update_jupyterlab-server-proxy?urlpath=lab) compared to [master](https://mybinder.org/v2/gh/betatim/vscode-binder/master?urlpath=lab)