### PR TITLE
Start vscode in current directory by default

### DIFF
--- a/jupyter_vscode_proxy/__init__.py
+++ b/jupyter_vscode_proxy/__init__.py
@@ -7,10 +7,11 @@ def setup_vscode():
         executable = "code-server"
         if not shutil.which(executable):
             raise FileNotFoundError("Can not find code-server in PATH")
-
-        working_dir = os.getenv("CODE_WORKINGDIR", None)
-        if working_dir is None:
-            working_dir = os.getenv("REPO_DIR", ".")
+        
+        # Start vscode in CODE_WORKINGDIR env variable if set
+        # If not, start in 'current directory', which is $REPO_DIR in mybinder
+        # but /home/jovyan (or equivalent) in JupyterHubs
+        working_dir = os.getenv("CODE_WORKINGDIR", ".")
 
         extensions_dir = os.getenv("CODE_EXTENSIONSDIR", None)
         extra_extensions_dir = os.getenv("CODE_EXTRA_EXTENSIONSDIR", None)


### PR DESCRIPTION
Current behavior is to start in $REPO_DIR if $CODE_WORKINGDIR is
not set. However, in JupyterHubs, you want to default to starting in
current working directory, which is often set to /home/jovyan or
similar. Current working directory is already set to $REPO_DIR in
mybinder.org by default, so this should be a no-op in mybinder.org
while doing the expected thing on JupyterHubs.