### PR TITLE
Add flag to run under conda environment

### DIFF
--- a/postBuild
+++ b/postBuild
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/bash -l
 
 # Enable the proxy extension in notebook and lab
 jupyter serverextension enable --py jupyter_server_proxy


### PR DESCRIPTION
Fixes #23 

I managed to debug inside the container that repo2docker generated and found that the problem was that `postBuild` does not run within the conda environment.

And the way to fix it was mentioned here https://github.com/jupyterhub/repo2docker/issues/411#issuecomment-494287603

