### PR TITLE
Only upload on release creation.

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -2,7 +2,7 @@ name: Build and upload to PyPI
 on: 
  push:
  release:
-   types: [created]
+   types: [published]
 
 jobs:
   build_artifacts:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,5 +1,8 @@
 name: Build and upload to PyPI
-on: [push, release]
+on: 
+ push:
+ release:
+   types: [created]
 
 jobs:
   build_artifacts:


### PR DESCRIPTION
Otherwise, we will have three jobs that try to upload the same artefact.