### PR TITLE
Add support for openvscode server

### DIFF
--- a/jupyter_vscode_proxy/__init__.py
+++ b/jupyter_vscode_proxy/__init__.py
@@ -27,8 +27,31 @@ def _get_vscode_cmd(port):
     return cmd
 
 
+def _get_openvscode_cmd(port):
+    executable = "openvscode-server"
+    if not shutil.which(executable):
+        raise FileNotFoundError("Can not find openvscode-server in PATH")
+
+    cmd = [
+        executable,
+        "--without-connection-token",
+        "--telemetry-level off",
+        "--port=" + str(port),
+    ]
+
+    if (extensions_dir := os.getenv("CODE_EXTENSIONSDIR", None)):
+        cmd += ["--extensions-dir", extensions_dir]
+
+    # Start openvscode in CODE_WORKINGDIR env variable if set
+    # If not, start in 'current directory'.
+    working_dir = os.getenv("CODE_WORKINGDIR", ".")
+    cmd.append(working_dir)
+    return cmd
+
+
 _CODE_EXECUTABLE_CMD_MAP = {
     "code-server": _get_vscode_cmd,
+    "openvscode-server": _get_openvscode_cmd,
 }
 
 

--- a/jupyter_vscode_proxy/__init__.py
+++ b/jupyter_vscode_proxy/__init__.py
@@ -1,8 +1,10 @@
+from typing import Callable, List, Dict, Any
+
 import os
 import shutil
 
 
-def _get_vscode_cmd():
+def _get_vscode_cmd() -> List[str]:
     return [
         "code-server",
         "--auth",
@@ -11,7 +13,7 @@ def _get_vscode_cmd():
     ]
 
 
-def _get_openvscode_cmd():
+def _get_openvscode_cmd() -> List[str]:
     return [
         "openvscode-server",
         "--without-connection-token",
@@ -19,19 +21,19 @@ def _get_openvscode_cmd():
     ]
 
 
-_CODE_EXECUTABLE_CMD_MAP = {
+_CODE_EXECUTABLE_CMD_MAP: Dict[str, Callable] = {
     "code-server": _get_vscode_cmd,
     "openvscode-server": _get_openvscode_cmd,
 }
 
 
-def _get_cmd_factory(executable):
+def _get_cmd_factory(executable: str) -> Callable:
     if executable not in _CODE_EXECUTABLE_CMD_MAP:
         raise KeyError(f"'{executable}' is not one of {_CODE_EXECUTABLE_CMD_MAP.keys()}.")
     
     get_cmd = _CODE_EXECUTABLE_CMD_MAP[executable]
 
-    def _get_cmd(port):
+    def _get_cmd(port: int) -> List[str]:
         if not shutil.which(executable):
             raise FileNotFoundError(f"Can not find {executable} in PATH")
         
@@ -55,7 +57,7 @@ def _get_cmd_factory(executable):
     return _get_cmd
 
 
-def setup_vscode():
+def setup_vscode() -> Dict[str, Any]:
     executable = os.environ.get("CODE_EXECUTABLE", "code-server")
     return {
         "command": _get_cmd_factory(executable),

--- a/jupyter_vscode_proxy/__init__.py
+++ b/jupyter_vscode_proxy/__init__.py
@@ -4,7 +4,7 @@ import os
 import shutil
 
 
-def _get_vscode_cmd() -> List[str]:
+def _get_inner_vscode_cmd() -> List[str]:
     return [
         "code-server",
         "--auth",
@@ -13,7 +13,7 @@ def _get_vscode_cmd() -> List[str]:
     ]
 
 
-def _get_openvscode_cmd() -> List[str]:
+def _get_inner_openvscode_cmd() -> List[str]:
     return [
         "openvscode-server",
         "--without-connection-token",
@@ -21,17 +21,17 @@ def _get_openvscode_cmd() -> List[str]:
     ]
 
 
-_CODE_EXECUTABLE_CMD_MAP: Dict[str, Callable] = {
-    "code-server": _get_vscode_cmd,
-    "openvscode-server": _get_openvscode_cmd,
+_CODE_EXECUTABLE_INNER_CMD_MAP: Dict[str, Callable] = {
+    "code-server": _get_inner_vscode_cmd,
+    "openvscode-server": _get_inner_openvscode_cmd,
 }
 
 
 def _get_cmd_factory(executable: str) -> Callable:
-    if executable not in _CODE_EXECUTABLE_CMD_MAP:
-        raise KeyError(f"'{executable}' is not one of {_CODE_EXECUTABLE_CMD_MAP.keys()}.")
+    if executable not in _CODE_EXECUTABLE_INNER_CMD_MAP:
+        raise KeyError(f"'{executable}' is not one of {_CODE_EXECUTABLE_INNER_CMD_MAP.keys()}.")
     
-    get_cmd = _CODE_EXECUTABLE_CMD_MAP[executable]
+    get_inner_cmd = _CODE_EXECUTABLE_INNER_CMD_MAP[executable]
 
     def _get_cmd(port: int) -> List[str]:
         if not shutil.which(executable):
@@ -44,7 +44,7 @@ def _get_cmd_factory(executable: str) -> Callable:
 
         extensions_dir = os.getenv("CODE_EXTENSIONSDIR", None)
 
-        cmd = get_cmd()
+        cmd = get_inner_cmd()
 
         cmd.append("--port=" + str(port))
 

--- a/jupyter_vscode_proxy/__init__.py
+++ b/jupyter_vscode_proxy/__init__.py
@@ -27,9 +27,17 @@ def _get_vscode_cmd(port):
     return cmd
 
 
+_CODE_EXECUTABLE_CMD_MAP = {
+    "code-server": _get_vscode_cmd,
+}
+
+
 def setup_vscode():
+    executable = os.environ.get("CODE_EXECUTABLE", "code-server")
+    if executable not in _CODE_EXECUTABLE_CMD_MAP:
+        raise KeyError(f"'{executable}' is not one of {_CODE_EXECUTABLE_CMD_MAP.keys()}.")
     return {
-        "command": _get_vscode_cmd,
+        "command": _CODE_EXECUTABLE_CMD_MAP[executable],
         "timeout": 300,
         "new_browser_tab": True,
         "launcher_entry": {

--- a/jupyter_vscode_proxy/__init__.py
+++ b/jupyter_vscode_proxy/__init__.py
@@ -17,7 +17,8 @@ def _get_inner_openvscode_cmd() -> List[str]:
     return [
         "openvscode-server",
         "--without-connection-token",
-        "--telemetry-level off",
+        "--telemetry-level",
+        "off",
     ]
 
 

--- a/jupyter_vscode_proxy/__init__.py
+++ b/jupyter_vscode_proxy/__init__.py
@@ -1,33 +1,33 @@
 import os
 import shutil
 
+def _get_vscode_cmd(port):
+    executable = "code-server"
+    if not shutil.which(executable):
+        raise FileNotFoundError("Can not find code-server in PATH")
+    
+    # Start vscode in CODE_WORKINGDIR env variable if set
+    # If not, start in 'current directory', which is $REPO_DIR in mybinder
+    # but /home/jovyan (or equivalent) in JupyterHubs
+    working_dir = os.getenv("CODE_WORKINGDIR", ".")
+
+    extensions_dir = os.getenv("CODE_EXTENSIONSDIR", None)
+    cmd = [
+        executable,
+        "--auth",
+        "none",
+        "--disable-telemetry",
+        "--port=" + str(port),
+    ]
+
+    if extensions_dir:
+        cmd += ["--extensions-dir", extensions_dir]
+
+    cmd.append(working_dir)
+    return cmd
+
 
 def setup_vscode():
-    def _get_vscode_cmd(port):
-        executable = "code-server"
-        if not shutil.which(executable):
-            raise FileNotFoundError("Can not find code-server in PATH")
-        
-        # Start vscode in CODE_WORKINGDIR env variable if set
-        # If not, start in 'current directory', which is $REPO_DIR in mybinder
-        # but /home/jovyan (or equivalent) in JupyterHubs
-        working_dir = os.getenv("CODE_WORKINGDIR", ".")
-
-        extensions_dir = os.getenv("CODE_EXTENSIONSDIR", None)
-        cmd = [
-            executable,
-            "--auth",
-            "none",
-            "--disable-telemetry",
-            "--port=" + str(port),
-        ]
-
-        if extensions_dir:
-            cmd += ["--extensions-dir", extensions_dir]
-
-        cmd.append(working_dir)
-        return cmd
-
     return {
         "command": _get_vscode_cmd,
         "timeout": 300,


### PR DESCRIPTION
[openvscode-server[(https://github.com/gitpod-io/openvscode-server) is a popular alternative to [code-server](https://github.com/coder/code-server). This PR adds support for openvscode-server to this package. You can toggle between the two through the `CODE_EXECUTABLE` environment variable.

I've also added type hints to the code base in https://github.com/betatim/vscode-binder/pull/39/commits/73a5764b188c193917b5e1c657606f30aa4b621f. I can remove that if it's not wanted.