### PR TITLE
Possibility to use pre-running code-server instead of starting a new one

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,3 +22,9 @@ To use pre-started code-server:
 
 If none of these environment variables are set, jupyter-code-server starts new code-server process and proxies
 requests to its socket.
+
+## Enable/disable launcher
+By default code-server launcher is enabled and visible in JupyterLab. Option `CODE_LAUNCHER_DISABLED`
+may be set to any non-empty value to disable launcher. This is useful when e.g. certain users are not supposed
+to have code-server available in Jupyterhub as there is no easy way to disable loading of entire `jupyter-vscode-proxy`
+module for these users if module is for example built into Docker image.

--- a/README.md
+++ b/README.md
@@ -6,3 +6,19 @@
 VS Code on Binder, because sometimes you need a real editor.
 
 Try it: [![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/betatim/vscode-binder/master?urlpath=lab)
+
+## Using pre-started code-server
+
+In case code-server is already running (e.g. started in sidecar container with Jupyter running in Kubernetes)
+and servig either via TCP port or UNIX socket, it is possible to proxy this already running instance instead
+of starting a new one with jupyter-server-proxy. Variables `CODE_EXECUTABLE=none` and `CODE_PRESTARTED_PORT`
+or `CODE_PRESTARTED_SOCKET` set `command` to empty list which makes `jupyter-server-proxy` pass requests
+to specified port of socket.
+
+To use pre-started code-server:
+- set `CODE_EXECUTABLE=none`
+    - set `CODE_PRESTARTED_PORT` to TCP port number listened by code-server
+    - set `CODE_PRESTARTED_SOCKET` to UNIX socket path code-server is listening to
+
+If none of these environment variables are set, jupyter-code-server starts new code-server process and proxies
+requests to its socket.

--- a/jupyter_vscode_proxy/__init__.py
+++ b/jupyter_vscode_proxy/__init__.py
@@ -75,6 +75,8 @@ def setup_vscode() -> Dict[str, Any]:
         "timeout": 300,
         "new_browser_tab": True,
         "launcher_entry": {
+            # Option to disable launcher, e.g. for users that are not supposed to have editor available
+            "enabled": False if os.environ.get('CODE_LAUNCHER_DISABLED') else True,
             "title": "VS Code",
             "icon_path": os.path.join(
                 os.path.dirname(os.path.abspath(__file__)), "icons", icon


### PR DESCRIPTION
Sometimes code-server is already running (e.g. in sidecar container with Jupyter singleuser in Kubernetes). For these cases there is no need to start a new code-server process, it's possible to just proxy requests to TCP port or UNIX socket of already running code-server.